### PR TITLE
Update util.js

### DIFF
--- a/src/tasks/util/util.js
+++ b/src/tasks/util/util.js
@@ -98,8 +98,7 @@ const fontFormats = 'eot,woff2,woff,ttf,svg';
  * @return {Array}
  */
 function generatedFontFiles(options) {
-  const mask = '*.{' + options.types + '}';
-
+  const mask = '.' + options.types;
   return glob.sync(path.join(options.dest, options.fontFilename + mask));
 }
 


### PR DESCRIPTION
brace expression not working in glob.sync, so removed to get types array directly to glob.sync