### PR TITLE
Add skipLinks option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ Type: `boolean` Default: `true`
 
 Append font file names with unique string to flush browser cache when you update your icons.
 
+#### skipLinks
+
+Type: `boolean` Default: `false`
+
+Ignore symbolic links when enumerating svg to convert.
+
 #### styles
 
 Type: `string|array` Default: `'font,icon'`

--- a/src/tasks/webfonts.js
+++ b/src/tasks/webfonts.js
@@ -88,7 +88,11 @@ module.exports = function webFonts(grunt) {
     }
 
     // Source files
-    const files = _(this.filesSrc).filter(isSvgFile).value();
+    let svgFiles = _(this.filesSrc).filter(isSvgFile);
+    if (options.skipLinks === true) {
+      svgFiles = svgFiles.filter(isFsLink);
+    }
+    const files = svgFiles.value();
 
     if (!files.length) {
       logger.warn('Specified empty list of source SVG files.');
@@ -677,6 +681,17 @@ module.exports = function webFonts(grunt) {
      */
     function isSvgFile(filepath) {
       return path.extname(filepath).toLowerCase() === '.svg';
+    }
+
+    /**
+     * Check whether file is link or not
+     *
+     * @param {String} filepath File path
+     * @return {Boolean}
+     */
+    function isFsLink(filepath) {
+      const stat = fs.lstatSync(filepath);
+      return stat.isSymbolicLink();
     }
 
     /**


### PR DESCRIPTION
Many fonts use symbolic links to reuse the same font for multiple actions. This patch allows filtering the SVGs that will be converted, ignoring or allowing symbolic links.