### PR TITLE
Ignore instead of taking only symbolic links if skipLinks is set.

### DIFF
--- a/src/tasks/webfonts.js
+++ b/src/tasks/webfonts.js
@@ -90,7 +90,7 @@ module.exports = function webFonts(grunt) {
     // Source files
     let svgFiles = _(this.filesSrc).filter(isSvgFile);
     if (options.skipLinks === true) {
-      svgFiles = svgFiles.filter(isFsLink);
+      svgFiles = svgFiles.reject(isFsLink);
     }
     const files = svgFiles.value();
 


### PR DESCRIPTION
The current implementation was filtering based on the `isFsLink()` function and therefore if `skipLinks` option was set it was including only svgs that are symbolic links.
This patch inverts the behavior to be consistent with the option name.