### PR TITLE
put b(binary) back infront of bytes join for better support of python3

### DIFF
--- a/tasks/bin/eotlitetool.py
+++ b/tasks/bin/eotlitetool.py
@@ -373,7 +373,7 @@ def make_eot_name_headers(fontdata, nameTableDir):
         else:
             nameheaders.append(struct.pack('4x'))  # len = 0, padding = 0
 
-    return ''.join(nameheaders)
+    return b''.join(nameheaders)
 
 # just return a null-string (len = 0)
 def make_root_string():
@@ -445,11 +445,11 @@ def make_eot_header(fontdata):
                         *([eotSize, fontDataSize, version, flags] + panose + [charset, italic] +
                           [weight, fsType, magicNumber] + urange + codepage + [checkSumAdjustment]))
 
-    return ''.join((fixed, nameheaders, rootstring))
+    return b''.join((fixed, nameheaders, rootstring))
 
 
 def write_eot_font(eot, header, data):
-    open(eot,'wb').write(''.join((header, data)))
+    open(eot,'wb').write(b''.join((header, data)))
     return
 
 def main():


### PR DESCRIPTION
This reverts PR [#356](https://github.com/sapegin/grunt-webfont/pull/356/files) from `grunt-webfont`.  I'm not positive when in python3 this broke, but in later versions, say >=3.7, the scripts silently fails to create eot files.  python2.7 ignores the `b` notation, so that should not impact earlier versions.  I've seen this in linux builds and recently in an osx build and we have validation that ensures all assets are built, so the build will fail if not on python2.7 or python3 (less than something, but i thought bytes were a big change for 3.0).  This change ensures they are generated, i will look for tests in the repo to confirm this change passes.