### PR TITLE
Add Zero Width Character Support

### DIFF
--- a/tasks/engines/fontforge/generate.py
+++ b/tasks/engines/fontforge/generate.py
@@ -74,6 +74,9 @@ for dirname, dirnames, filenames in os.walk(args['inputDir']):
 
             if args['normalize']:
                 glyph.left_side_bearing = glyph.right_side_bearing = 0
+            elif name[1:] in args['zerowidth']:
+                glyph.left_side_bearing = glyph.right_side_bearing = 0
+                glyph.width = 0
             else:
                 glyph.width = args['fontHeight']
 

--- a/tasks/webfonts.js
+++ b/tasks/webfonts.js
@@ -141,6 +141,7 @@ module.exports = function webFonts(grunt) {
       ie7: options.ie7 === true,
       centerHorizontally: options.centerHorizontally === true,
       normalize: options.normalize === true,
+      zerowidth: options.zerowidth || [],
       round: options.round !== undefined ? options.round : 10e12,
       fontHeight: options.fontHeight !== undefined ? options.fontHeight : 512,
       descent: options.descent !== undefined ? options.descent : 64,


### PR DESCRIPTION
Created a new 'zerowidth' option, which is an array of characters that should be rendered with no width or side bearings.

The relevant SVG file(s) still need to exist, but a `0` wide viewport object should suffice, so long as it has some simple vertical path inside to parse.

Example use, with the Keycap character, `u20e3`:

20e3.svg:
```<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 36"><path fill="#FFFFFF00" d="M0 0 V 36 z"/></svg>```

Gruntfile.js:
```
options: {
    ...
    autoHint: false,
    zerowidth: ['20e3'],
    ...
}
```

You can even make a character have a negative width to cause an overlap on the previous character, allowing for modifiers.